### PR TITLE
Refactor hosting services & combine duplicated code into `TcpService`

### DIFF
--- a/PenguinCS.Common/Interfaces/IClientHandler.cs
+++ b/PenguinCS.Common/Interfaces/IClientHandler.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Hosting;
+using System.Threading.Tasks;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace PenguinCS.Common.Interfaces;
+
+public interface IClientHandler
+{
+    Task AcceptClientAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/PenguinCS.Common/PenguinCS.Common.csproj
+++ b/PenguinCS.Common/PenguinCS.Common.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PenguinCS.Common/TcpService.cs
+++ b/PenguinCS.Common/TcpService.cs
@@ -54,10 +54,6 @@ public class TcpService(
 
         await cancellationTokenSource.CancelAsync();
         Listener.Stop();
-
-        // Give a brief moment to complete ongoing tasks
-        await Task.Delay(500, CancellationToken.None);
-
         Logger.LogInformation("{name} stopped.", Name);
     }
 

--- a/PenguinCS.Common/TcpService.cs
+++ b/PenguinCS.Common/TcpService.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Net;
+using System.Xml;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using PenguinCS.Common.Interfaces;
+using PenguinCS.Common.Enums;
+using StackExchange.Redis;
+
+namespace PenguinCS.Common;
+
+public class TcpService(
+    ILogger<TcpService> logger,
+    IConnectionMultiplexer redis,
+    MessageProcessor processor
+) : IClientHandler, IHostedService
+{
+    private CancellationTokenSource cancellationTokenSource;
+    protected readonly MessageProcessor Processor = processor;
+    protected readonly IConnectionMultiplexer Redis = redis;
+    protected readonly ILogger Logger = logger;
+    protected TcpListener Listener;
+    
+    protected virtual string Name => "Server";
+    protected virtual int Port => 8000;
+    
+    public virtual async Task AcceptClientAsync(CancellationToken cancellationToken)
+    {
+    }
+    
+    public virtual async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+    }
+    
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        Listener = new TcpListener(IPAddress.Any, Port);
+        Listener.Start();
+        Logger.LogInformation("{name} started on port {port}", Name, Port);
+
+        _ = AcceptClientAsync(cancellationTokenSource.Token);
+
+        return Task.CompletedTask;
+    }
+    
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        Logger.LogInformation("Stopping {name}...", Name);
+
+        await cancellationTokenSource.CancelAsync();
+        Listener.Stop();
+
+        // Give a brief moment to complete ongoing tasks
+        await Task.Delay(500, CancellationToken.None);
+
+        Logger.LogInformation("{name} stopped.", Name);
+    }
+
+    protected (EMessageFormat format, string idOrAction, string extension) ResolveMessageInfo(string messageContent)
+    {
+        if (messageContent.StartsWith("<policy-file-request/>"))
+        {
+            // We received a flash socket policy request, which serves a similar purpose to CORS
+            // nowadays. Usually, there is an external policy server running on port 843; however
+            // once that one is not available this is used as a backup.
+            return (EMessageFormat.XML, "policy-file-request", string.Empty);
+        }
+        
+        // XML Packets
+        if (messageContent.StartsWith('<'))
+        {
+            XmlDocument xml = new();
+            xml.LoadXml(messageContent);
+            
+            XmlElement rootElement = xml.DocumentElement;
+            
+            if (rootElement == null)
+                throw new InvalidOperationException($"No root element found for {messageContent}");
+            
+            // Check the action attribute on the body
+            XmlNode bodyNode = rootElement.SelectSingleNode("body");
+            string actionAttribute = ((XmlElement)bodyNode)?.GetAttribute("action");
+            
+            return (EMessageFormat.XML, actionAttribute, string.Empty);
+        }
+        
+        // XT Packets
+        if (messageContent.StartsWith("%xt%"))
+        {
+            // Example: %xt%s%j#js%-1%101%d41d8cd98f00b204e9800998ecf8427e%en%
+            
+            // Message Parts:
+            // 1: Blank
+            // 2: xt
+            // 3: s
+            // 4: id#ext (e.g. j#js)
+            
+            // Parse message parts
+            var xtParts = messageContent.Split('%');
+            
+            // Parse 'id' & 'ext'
+            var xtData = xtParts[3].Split('#');
+            var id = xtData[0];
+            var extension = xtData[1];
+            
+            return (EMessageFormat.XT, id, extension);
+        }
+        
+        throw new InvalidOperationException("Unknown message type");
+    }
+}

--- a/PenguinCS.Common/TcpService.cs
+++ b/PenguinCS.Common/TcpService.cs
@@ -86,10 +86,9 @@ public class TcpService(
         }
         
         // XT Packets
+        // Example: %xt%s%j#js%-1%101%d41d8cd98f00b204e9800998ecf8427e%en%
         if (messageContent.StartsWith("%xt%"))
         {
-            // Example: %xt%s%j#js%-1%101%d41d8cd98f00b204e9800998ecf8427e%en%
-            
             // Message Parts:
             // 1: Blank
             // 2: xt

--- a/PenguinCS.Login/LoginHostedService.cs
+++ b/PenguinCS.Login/LoginHostedService.cs
@@ -40,7 +40,7 @@ internal class LoginHostedService(
 
     public override async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Client {RemoteEndPoint} connected.", client.Client.RemoteEndPoint);
+        Logger.LogInformation("Client {RemoteEndPoint} connected.", client.Client.RemoteEndPoint);
         var stream = client.GetStream();
         
         try
@@ -54,7 +54,7 @@ internal class LoginHostedService(
                     break;
                 }
 
-                logger.LogTrace("Received from {RemoteEndPoint}: {message}", client.Client.RemoteEndPoint, messageContent);
+                Logger.LogTrace("Received from {RemoteEndPoint}: {message}", client.Client.RemoteEndPoint, messageContent);
 
                 var (messageFormat, idOrAction, extension) = ResolveMessageInfo(messageContent);
 
@@ -73,12 +73,12 @@ internal class LoginHostedService(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error handling client.");
+            Logger.LogError(ex, "Error handling client.");
         }
         finally
         {
             client.Close();
-            logger.LogInformation("Client disconnected.");
+            Logger.LogInformation("Client disconnected.");
         }
     }
 }

--- a/PenguinCS.Login/LoginHostedService.cs
+++ b/PenguinCS.Login/LoginHostedService.cs
@@ -20,7 +20,7 @@ internal class LoginHostedService(
 ) : TcpService(logger, redis, processor)
 {
     protected override string Name => "Login Server";
-    protected override int Port => 6112;
+    protected override int Port => 9912;
     
     public override async Task AcceptClientAsync(CancellationToken cancellationToken)
     {

--- a/PenguinCS.Login/LoginHostedService.cs
+++ b/PenguinCS.Login/LoginHostedService.cs
@@ -13,87 +13,58 @@ using StackExchange.Redis;
 
 namespace PenguinCS.Login;
 
-internal class LoginHostedService(ILogger<LoginHostedService> logger, IConnectionMultiplexer redis, MessageProcessor processor) : IHostedService
+internal class LoginHostedService(
+    ILogger<TcpService> logger, 
+    IConnectionMultiplexer redis, 
+    MessageProcessor processor
+) : TcpService(logger, redis, processor)
 {
-    private readonly ILogger<LoginHostedService> _logger = logger;
-    private readonly IConnectionMultiplexer _redis = redis;
-    private readonly MessageProcessor _processor = processor;
-    private TcpListener _listener;
-    private CancellationTokenSource _cancellationTokenSource;
-
-    public Task StartAsync(CancellationToken cancellationToken)
-    {
-        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-        // TODO: Get from Config
-        var port = 9912;
-
-        _listener = new TcpListener(IPAddress.Any, port);
-        _listener.Start();
-        _logger.LogInformation("Login Server started on port {port}", port);
-
-        _ = AcceptClientAsync(_cancellationTokenSource.Token);
-
-        return Task.CompletedTask;
-    }
-
-    public async Task StopAsync(CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Stopping Login Server...");
-
-        _cancellationTokenSource.Cancel();
-        _listener.Stop();
-
-        await Task.Delay(500, CancellationToken.None); // Give a brief moment to complete ongoing tasks
-
-        _logger.LogInformation("Login Server stopped.");
-    }
-
-    private async Task AcceptClientAsync(CancellationToken cancellationToken)
+    protected override string Name => "Login Server";
+    protected override int Port => 6112;
+    
+    public override async Task AcceptClientAsync(CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
-                var client = await _listener.AcceptTcpClientAsync(cancellationToken);
+                var client = await Listener.AcceptTcpClientAsync(cancellationToken);
                 _ = HandleClientAsync(client, cancellationToken);
             }
-            catch (Exception ex) when (ex is ObjectDisposedException || ex is InvalidOperationException)
+            catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException)
             {
                 break;
             }
         }
     }
 
-    private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+    public override async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Client {RemoteEndPoint} connected.", client.Client.RemoteEndPoint);
+        logger.LogInformation("Client {RemoteEndPoint} connected.", client.Client.RemoteEndPoint);
         var stream = client.GetStream();
-
+        
         try
         {
-            var redis = _redis.GetDatabase();
-
             while (client.Connected && !cancellationToken.IsCancellationRequested)
             {
-                string messageContent = stream.ReadUTF8NullTerminatedString();
+                var messageContent = await stream.ReadUTF8NullTerminatedStringAsync(cancellationToken);
 
                 if (string.IsNullOrWhiteSpace(messageContent))
                 {
                     break;
                 }
 
-                _logger.LogTrace("Received from {RemoteEndPoint}: {message}", client.Client.RemoteEndPoint, messageContent);
+                logger.LogTrace("Received from {RemoteEndPoint}: {message}", client.Client.RemoteEndPoint, messageContent);
 
-                var (messageFormat, idOrAction, extension) = GetMessageInfo(messageContent);
+                var (messageFormat, idOrAction, extension) = ResolveMessageInfo(messageContent);
 
                 switch (messageFormat)
                 {
                     case EMessageFormat.XML:
-                        await _processor.ProcessXMLMessageAsync(messageContent, idOrAction, stream, cancellationToken);
+                        await Processor.ProcessXMLMessageAsync(messageContent, idOrAction, stream, cancellationToken);
                         break;
                     case EMessageFormat.XT:
-                        await _processor.ProcessXTMessageAsync(messageContent, idOrAction, extension, stream, cancellationToken);
+                        await Processor.ProcessXTMessageAsync(messageContent, idOrAction, extension, stream, cancellationToken);
                         break;
                     default:
                         throw new InvalidOperationException("Unknown message type");
@@ -102,47 +73,12 @@ internal class LoginHostedService(ILogger<LoginHostedService> logger, IConnectio
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error handling client.");
+            logger.LogError(ex, "Error handling client.");
         }
         finally
         {
             client.Close();
-            _logger.LogInformation("Client disconnected.");
-        }
-    }
-
-    private (EMessageFormat format, string idOrAction, string extension) GetMessageInfo(string messageContent)
-    {
-        if (messageContent.StartsWith("<policy-file-request/>"))
-        {
-            return (EMessageFormat.XML, "policy-file-request", string.Empty);
-        }
-        else if (messageContent.StartsWith('<'))
-        {
-            // XML Packet, check the action attribute on the body
-            XmlDocument xmlDoc = new();
-            xmlDoc.LoadXml(messageContent);
-
-            XmlElement rootElement = xmlDoc.DocumentElement;
-            XmlNode bodyNode = rootElement.SelectSingleNode("body");
-            string actionAttribute = ((XmlElement)bodyNode).GetAttribute("action");
-
-            return (EMessageFormat.XML, actionAttribute, string.Empty);
-        }
-        else if (messageContent.StartsWith("%xt%"))
-        {
-            // XT Packet, get ext and id
-            var parts = messageContent.Split('%');
-            // 1: blank. 2: xt. 3: s. 4: id#ext
-            var data = parts[3].Split('#');
-            var id = data[0];
-            var extension = data[1];
-
-            return (EMessageFormat.XT, id, extension);
-        }
-        else
-        {
-            throw new InvalidOperationException("Unknown message type");
+            logger.LogInformation("Client disconnected.");
         }
     }
 }


### PR DESCRIPTION
I was recently interested in checking out this project and decided to work on one of the issues that were open.
It does what the name suggests; both `GameHostedService` and `LoginHostedService` now re-use code from `TcpService` in `PenguinCS.Common`. Given my rusty C# skills, there could be some bad practices, and I also wasn't sure where to place the `TcpService.cs`. Feel free to make changes :saluting_face: 

Resolves #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new TCP service component for handling client connections and message processing.
- **Refactor**
  - Simplified and unified the structure of game and login server services by introducing a shared base class for TCP server functionality.
  - Updated both game and login services to inherit from the new base class, reducing code duplication and improving maintainability.
- **Chores**
  - Added a new dependency on the StackExchange.Redis library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->